### PR TITLE
Resolve precision issues

### DIFF
--- a/softsplat.py
+++ b/softsplat.py
@@ -349,7 +349,9 @@ def FunctionSoftsplat(tenInput, tenFlow, tenMetric, strType):
 	tenOutput = _FunctionSoftsplat.apply(tenInput, tenFlow)
 
 	if strType != 'summation':
-		tenOutput = tenOutput[:, :-1, :, :] / (tenOutput[:, -1:, :, :] + 0.0000001)
+		tenSplattedMetric = tenOutput[:, -1:, :, :]
+		tenSplattedMetric[tenSplattedMetric == 0] = 1
+		tenOutput = tenOutput[:, :-1, :, :] / tenSplattedMetric
 	# end
 
 	return tenOutput


### PR DESCRIPTION
When dividing the accumulated output tensor by the summed weights, an epsilon is added, presumably to prevent division by zero, which happens when no input values splat to a particular destination pixel. 

However, if there are splatted values to a particular destination pixel, but the metric values are small enough (say -50 as an input metric, which becomes e^-50 ~= 1e-44), the addition of `eps=0.0000001` prior to division causes precision errors, effectively clobbering the accumulated metric. 

With this change, the logic for preventing divide-by-zero is only applied to pixels which have zero splatted metric.

I've tested the change, it seems to produce the correct result for all metric values. There may be a minor performance hit on certain machines due to the conditional assignment on line 353, but in my tests (`B=32`, `H,W=512`, `C=64` -- 2080 Ti), the timing measurements actually seem to be negligibly faster with this change, not sure why.  I've also experimented with the alternative of creating a mask tensor and only evaluating the quotient at non-zero pixels, but that ends up being slightly slower.